### PR TITLE
Add base message class to message component

### DIFF
--- a/src/Bulma/Components.elm
+++ b/src/Bulma/Components.elm
@@ -646,7 +646,8 @@ messageModifiers
 message : MessageModifiers -> List (Attribute msg) -> List (MessagePartition msg) -> Message msg
 message {color,size}
   = node "article"
-    [ case color of
+    [ B.message
+    , case color of
         Default -> B.none
         White   -> B.isWhite
         Light   -> B.isLight


### PR DESCRIPTION
The message component renders without the `message` class which results in the expected styles (e.g. colors) not being applied.