### PR TITLE
Fix navbarBurger tag from <a> to <div> avoiding page reload.

### DIFF
--- a/src/Bulma/Components.elm
+++ b/src/Bulma/Components.elm
@@ -1073,7 +1073,7 @@ When its first argument is `True`, it transforms into a `navbarCross`.
 
 -}
 navbarBurger : IsActive -> List (Attribute msg) -> List (Html msg) -> NavbarBurger msg
-navbarBurger isActive = node "a" [ B.navbarBurger, if isActive then B.isActive else B.none ]
+navbarBurger isActive = node "div" [ B.navbarBurger, if isActive then B.isActive else B.none ]
 
 {-| A simple "X" character; the active version of `navbarBurger`.
 -}


### PR DESCRIPTION
When following the example provided in [documentation](https://package.elm-lang.org/packages/surprisetalk/elm-bulma/latest/Bulma-Components#navbar), clicking on the burger triggers a page reload. As suggested in an issue on the [official Bulma GitHub repository](https://github.com/jgthms/bulma/issues/1515), changing the `<a>` to a `<div>` fixes the problem.

**Elm version**: `0.19.1`
**OS**: `macOS Catalina 10.15.1`